### PR TITLE
build: assign kwilClient.Signer to Client.Signer

### DIFF
--- a/core/tsnclient/client.go
+++ b/core/tsnclient/client.go
@@ -33,6 +33,7 @@ func NewClient(ctx context.Context, provider string, options ...Option) (*Client
 		return nil, err
 	}
 	c.kwilClient = kwilClient
+	c.Signer = kwilClient.Signer
 	for _, option := range options {
 		option(c)
 	}

--- a/core/tsnclient/client.go
+++ b/core/tsnclient/client.go
@@ -39,7 +39,9 @@ func NewClient(ctx context.Context, provider string, options ...Option) (*Client
 	}
 
 	// Validate the client
-	err = c.Validate()
+	if err = c.Validate(); err != nil {
+		return nil, err
+	}
 
 	return c, nil
 }


### PR DESCRIPTION
assigned kwilClient.Signer into c.Singer to properly pass the validation.

Alternatively, remove `Signer` since it is already in kwilClient anyway.

resolves: https://github.com/truflation/tsn-sdk/issues/9