### PR TITLE
fix: able to deploy stream without getting error

### DIFF
--- a/core/contractsapi/composed_stream.go
+++ b/core/contractsapi/composed_stream.go
@@ -25,8 +25,8 @@ func ComposedStreamFromStream(stream Stream) (*ComposedStream, error) {
 	}, nil
 }
 
-func NewComposedStream(opts NewStreamOptions) (*ComposedStream, error) {
-	stream, err := NewStream(opts)
+func LoadComposedStream(opts NewStreamOptions) (*ComposedStream, error) {
+	stream, err := LoadStream(opts)
 	if err != nil {
 		return nil, err
 	}

--- a/core/contractsapi/deploy_stream.go
+++ b/core/contractsapi/deploy_stream.go
@@ -20,12 +20,11 @@ type DeployStreamInput struct {
 }
 
 type DeployStreamOutput struct {
-	DeployedStream Stream
-	TxHash         transactions.TxHash
+	TxHash transactions.TxHash
 }
 
 // DeployStream deploys a stream to TSN
-func DeployStream(ctx context.Context, input DeployStreamInput) (*DeployStreamOutput, error) {
+func DeployStream(ctx context.Context, input DeployStreamInput) (transactions.TxHash, error) {
 	contractContent, err := GetContractContent(input)
 	schema, err := parse.Parse(contractContent)
 	if err != nil {
@@ -34,26 +33,7 @@ func DeployStream(ctx context.Context, input DeployStreamInput) (*DeployStreamOu
 
 	schema.Name = input.StreamId.String()
 
-	txHash, err := input.KwilClient.DeployDatabase(ctx, schema)
-	if err != nil {
-		return nil, err
-	}
-
-	options := NewStreamOptions{
-		Client:   input.KwilClient,
-		StreamId: input.StreamId,
-		Deployer: input.Deployer,
-	}
-
-	deployedStream, err := NewStream(options)
-	if err != nil {
-		return nil, err
-	}
-
-	return &DeployStreamOutput{
-		DeployedStream: *deployedStream,
-		TxHash:         txHash,
-	}, nil
+	return input.KwilClient.DeployDatabase(ctx, schema)
 }
 
 // GetContractContent returns the contract content based on the stream type

--- a/core/contractsapi/primitive_stream.go
+++ b/core/contractsapi/primitive_stream.go
@@ -24,8 +24,8 @@ func PrimitiveStreamFromStream(stream Stream) (*PrimitiveStream, error) {
 	}, nil
 }
 
-func NewPrimitiveStream(options NewStreamOptions) (*PrimitiveStream, error) {
-	stream, err := NewStream(options)
+func LoadPrimitiveStream(options NewStreamOptions) (*PrimitiveStream, error) {
+	stream, err := LoadStream(options)
 	if err != nil {
 		return nil, err
 	}

--- a/core/tsnclient/client.go
+++ b/core/tsnclient/client.go
@@ -77,17 +77,12 @@ func (c *Client) GetKwilClient() *kwilClientPkg.Client {
 }
 
 func (c *Client) DeployStream(ctx context.Context, streamId util.StreamId, streamType clientType.StreamType) (transactions.TxHash, error) {
-	out, err := tsn_api.DeployStream(ctx, tsn_api.DeployStreamInput{
+	return tsn_api.DeployStream(ctx, tsn_api.DeployStreamInput{
 		StreamId:   streamId,
 		StreamType: streamType,
 		KwilClient: c.kwilClient,
 		Deployer:   c.kwilClient.Signer.Identity(),
 	})
-	if err != nil {
-		return transactions.TxHash{}, err
-	}
-
-	return out.TxHash, nil
 }
 
 func (c *Client) DestroyStream(ctx context.Context, streamId util.StreamId) (transactions.TxHash, error) {
@@ -103,7 +98,7 @@ func (c *Client) DestroyStream(ctx context.Context, streamId util.StreamId) (tra
 }
 
 func (c *Client) LoadStream(streamLocator clientType.StreamLocator) (clientType.IStream, error) {
-	return tsn_api.NewStream(tsn_api.NewStreamOptions{
+	return tsn_api.LoadStream(tsn_api.NewStreamOptions{
 		Client:   c.kwilClient,
 		StreamId: streamLocator.StreamId,
 		Deployer: streamLocator.DataProvider.Bytes(),
@@ -111,7 +106,7 @@ func (c *Client) LoadStream(streamLocator clientType.StreamLocator) (clientType.
 }
 
 func (c *Client) LoadPrimitiveStream(streamLocator clientType.StreamLocator) (clientType.IPrimitiveStream, error) {
-	return tsn_api.NewPrimitiveStream(tsn_api.NewStreamOptions{
+	return tsn_api.LoadPrimitiveStream(tsn_api.NewStreamOptions{
 		Client:   c.kwilClient,
 		StreamId: streamLocator.StreamId,
 		Deployer: streamLocator.DataProvider.Bytes(),
@@ -119,7 +114,7 @@ func (c *Client) LoadPrimitiveStream(streamLocator clientType.StreamLocator) (cl
 }
 
 func (c *Client) LoadComposedStream(streamLocator clientType.StreamLocator) (clientType.IComposedStream, error) {
-	return tsn_api.NewComposedStream(tsn_api.NewStreamOptions{
+	return tsn_api.LoadComposedStream(tsn_api.NewStreamOptions{
 		Client:   c.kwilClient,
 		StreamId: streamLocator.StreamId,
 		Deployer: streamLocator.DataProvider.Bytes(),


### PR DESCRIPTION
resolves: https://github.com/truflation/tsn-sdk/issues/35

I separated `NewStream` into `NewStream` and `LoadStream`
The difference is, that `NewStream` just like its name, creates something new, while `LoadStream` needs to load something that exists (that's why we need to check it)