### PR TITLE
fix: unnecessary set of date and value on the optimized contract

### DIFF
--- a/core/contracts/composed_stream_template.kf
+++ b/core/contracts/composed_stream_template.kf
@@ -343,7 +343,7 @@ procedure get_record($date_from text, $date_to text, $frozen_at int) public view
         if $in_range == false {
             if $row.date_value >= $date_from {
                 $in_range := true;
-                if $last_date is distinct from null {
+                if ($last_date is distinct from null) AND $row.date_value != $date_from {
                     return next $last_date, $last_value;
                 }
             }
@@ -384,7 +384,7 @@ procedure get_index($date_from text, $date_to text, $frozen_at int) public view 
         if $in_range == false {
             if $row.date_value >= $date_from {
                 $in_range := true;
-                if $last_date is distinct from null {
+                if ($last_date is distinct from null) AND $row.date_value != $date_from {
                     return next $last_date, $last_value;
                 }
             }


### PR DESCRIPTION
I will sync tsn and tsn-data-provider after this one merged.

```
kwil-cli database call -a=get_record date_from:2024-09-01 date_to:2024-09-09 -n=st1b148397e2ea36889efad820e2315d
| date_value |  value   |
+------------+----------+
| 2024-09-01 | 8527.336 |
| 2024-09-02 | 8490.750 |
```

```
kwil-cli database call -a=get_record date_from:2024-08-31 date_to:2024-09-09 -n=st1b148397e2ea36889efad820e2315d
| date_value |  value   |
+------------+----------+
| 2024-08-30 | 8527.194 |
| 2024-09-01 | 8527.336 |
```

```
kwil-cli database call -a=get_record date_from:2024-08-30 date_to:2024-09-09 -n=st1b148397e2ea36889efad820e2315d
| date_value |  value   |
+------------+----------+
| 2024-08-30 | 8527.194 |
| 2024-09-01 | 8527.336 |
```

everything is in correct ways