### PR TITLE
fix: incorrect base value fetched after base date

### DIFF
--- a/core/contracts/primitive_stream.kf
+++ b/core/contracts/primitive_stream.kf
@@ -331,12 +331,19 @@ procedure get_index($date_from text, $date_to text, $frozen_at int, $base_date t
     return SELECT date_value, (value * 100::decimal(36,18)) / $baseValue as value FROM get_record($date_from, $date_to, $frozen_at);
 }
 
-// get_base_value returns the first value of the primitive stream after the given date
+// get_base_value returns the first nearest value of the primitive stream before the given date
 procedure get_base_value($base_date text, $frozen_at int) private view returns (value decimal(36,18)) {
-    for $row in SELECT * FROM get_first_record($base_date, $frozen_at) {
+    for $row in SELECT * FROM primitive_events WHERE date_value <= $base_date AND (created_at <= $frozen_at OR $frozen_at = 0 OR $frozen_at IS NULL) ORDER BY date_value DESC, created_at DESC LIMIT 1 {
         return $row.value;
     }
 
+    // if no value is found, we find the first value after the given date
+    // This will raise a red flag in the system and the data will undergo the usual process for when a new data provider is added.
+    for $row2 in SELECT * FROM primitive_events WHERE date_value > $base_date AND (created_at <= $frozen_at OR $frozen_at = 0 OR $frozen_at IS NULL) ORDER BY date_value ASC, created_at DESC LIMIT 1 {
+        return $row2.value;
+    }
+
+    // if no value is found, we return an error
     error('no base value found');
 }
 
@@ -364,7 +371,7 @@ procedure get_first_record($after_date text, $frozen_at int) public view returns
         $frozen_at := 0;
     }
 
-    return SELECT date_value, value FROM primitive_events WHERE date_value >= $after_date AND (created_at <= $frozen_at OR $frozen_at = 0) ORDER BY date_value ASC, created_at DESC LIMIT 1;
+    return SELECT date_value, value FROM primitive_events WHERE date_value >= $after_date AND (created_at <= $frozen_at OR $frozen_at = 0 OR $frozen_at IS NULL) ORDER BY date_value ASC, created_at DESC LIMIT 1;
 }
 
 // get_original_record returns the original value of the primitive stream for a given date


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above by following our Developer Guidelines -->

## Description
<!--- Describe your changes in detail; use bullet points. -->

I am matching the methodology here

```
Base Value: This is selected by first looking for a data point for 2010-01-01. If there is no
value on that date, the system will find the first value before that date (for example
2009-12-28) and set the index value for 2010-01-01 at 100.0. If there is no data for
2010-01-01, the system will select the closest available value after this date for this data
point. This will raise a red flag in the system and the data will undergo the usual process
for when a new data provider is added.
```

## Related Problem
<!--- If this pull request relates to an existing Problem, please link to it here (https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
<!-- example: 

resolves: #112330

-->

resolves: https://github.com/truflation/tsn/issues/672

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
