### PR TITLE
feat: default base date procedure

### DIFF
--- a/core/contracts/composed_stream_template.kf
+++ b/core/contracts/composed_stream_template.kf
@@ -399,13 +399,21 @@ procedure get_index($date_from text, $date_to text, $frozen_at int, $base_date t
     $in_range bool := false;
     $last_date text;
     $last_value decimal(36,18);
+    $effective_base_date text := $base_date;
+
+    if $effective_base_date is null OR $effective_base_date == '' {
+        for $v_row in SELECT * FROM get_metadata('default_base_date', true, null) LIMIT 1 {
+            $effective_base_date := $v_row.value_s;
+        }
+    }
+
     // here, we sum all of the indexes that were found by aggregating on the date_value
     for $row in SELECT date_value, total_value_with_weight / total_weight as value FROM
         (SELECT
             date_value,
             SUM(value_with_weight)::decimal(36,18) AS total_value_with_weight,
             SUM(weight)::decimal(36,18) AS total_weight
-        FROM get_index_filled($date_from, $date_to, $frozen_at, $base_date) group by date_value) as r {
+        FROM get_index_filled($date_from, $date_to, $frozen_at, $effective_base_date) group by date_value) as r {
         // when we arrive in the range, we start emitting. If there was a previous value, we emit it
         if $in_range == false {
             if $row.date_value >= $date_from {
@@ -627,6 +635,10 @@ procedure insert_metadata(
     // insert data
     INSERT INTO metadata (row_id, metadata_key, value_i, value_f, value_s, value_b, value_ref, created_at)
         VALUES ($uuid, $key, $value_i, $value_f, $value_s, $value_b, LOWER($value_ref), $current_block);
+}
+
+procedure insert_default_base_date($base_date text) public {
+    insert_metadata('default_base_date', $base_date, 'string');
 }
 
 // key: the metadata key to look for

--- a/core/contracts/primitive_stream.kf
+++ b/core/contracts/primitive_stream.kf
@@ -198,6 +198,10 @@ procedure insert_metadata(
         VALUES ($uuid, $key, $value_i, $value_f, $value_s, $value_b, LOWER($value_ref), $current_block);
 }
 
+procedure insert_default_base_date($base_date text) public {
+    insert_metadata('default_base_date', $base_date, 'string');
+}
+
 // key: the metadata key to look for
 // only_latest: if true, only return the latest version of the metadata
 // ref: if provided, only return metadata with that ref
@@ -323,7 +327,14 @@ procedure get_index($date_from text, $date_to text, $frozen_at int, $base_date t
         value decimal(36,18)
         ) {
 
-    $baseValue decimal(36,18) := get_base_value($base_date, $frozen_at);
+    $effective_base_date text := $base_date;
+    if ($effective_base_date == '') {
+        for $v_row in SELECT * FROM get_metadata('default_base_date', true, null) LIMIT 1 {
+            $effective_base_date := $v_row.value_s;
+        }
+    }
+
+    $baseValue decimal(36,18) := get_base_value($effective_base_date, $frozen_at);
     if $baseValue == 0::decimal(36,18) {
         error('base value is 0');
     }


### PR DESCRIPTION
## Description
Update primitive and composed contracts:
- Adding new procedure called `insert_default_base_date`
- Adding checking to use `default_base_date` if the `base_date` requested is null in `get_index` procedures

## Related Problem
resolves: #57 

## How Has This Been Tested?